### PR TITLE
Restore conversion branch to a usable (compiling) state

### DIFF
--- a/extensions/simd/intel/avx512.yaml
+++ b/extensions/simd/intel/avx512.yaml
@@ -44,5 +44,5 @@ simdT_mask_type: |-
                      )
                   )
 intrin_tp: {uint8_t: ["epu", 8], uint16_t: ["epu", 16], uint32_t: ["epu", 32], uint64_t: ["epu", 64], int8_t: ["epi", 8], int16_t: ["epi", 16], int32_t: ["epi", 32], int64_t: ["epi", 64], float: ["p", "s"], double: ["p", "d"]}
-intrin_tp_full: {uint8_t: "epu8", uint16_t: "epu16", uint32_t: "epu32", uint64_t: "epi64", int8_t: "epi8", int16_t: "epi16", int32_t: "epi32", int64_t: "epi64", float: "ps", double: "pd"}
+intrin_tp_full: {uint8_t: "epu8", uint16_t: "epu16", uint32_t: "epu32", uint64_t: "epu64", int8_t: "epi8", int16_t: "epi16", int32_t: "epi32", int64_t: "epi64", float: "ps", double: "pd"}
 ...

--- a/primitives/convert.yaml
+++ b/primitives/convert.yaml
@@ -612,7 +612,7 @@ testing:
 definitions:
 #INTEL - AVX2
   - target_extension: "avx2"
-    ctype:  [] # FIXME: these implementations don't compile: ["int32_t", "uint32_t"]
+    ctype:  ["int32_t", "uint32_t"]
     additional_simd_template_base_type: ["int8_t", "uint8_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -651,7 +651,7 @@ definitions:
 #        _mm256_cvtepi8_epi64(_mm_bsrli_si128(y, 12)),
 #      } };
   - target_extension: "avx2"
-    ctype: [] # FIXME: these implementations don't compile: ["int32_t", "uint32_t"]
+    ctype: ["int32_t", "uint32_t"]
     additional_simd_template_base_type: ["int16_t", "uint16_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -659,18 +659,19 @@ definitions:
       auto const upper_zero = _mm256_set1_epi32(0xffff);
       auto const d0 = _mm256_and_si256(upper_zero, data[0]);
       auto const d1 = _mm256_and_si256(upper_zero, data[1]);
+      using zext = functors::cast<simd<Vec::base_type, sse>, simd<Vec::base_type, avx2>, Idof>; 
       return
         _mm256_shuffle_epi8(
           _mm256_permute2x128_si256(
             _mm256_or_si256(
-              _mm256_zextsi128_si256(
+              zext::apply(
                 _mm256_extracti128_si256(
                   d0,
                   0
                 )
               ),
               _mm256_bslli_epi128(
-                _mm256_zextsi128_si256(
+                zext::apply(
                   _mm256_extracti128_si256(
                     d0,
                     1
@@ -680,14 +681,14 @@ definitions:
               )
             ),
             _mm256_or_si256(
-              _mm256_zextsi128_si256(
+              zext::apply(
                 _mm256_extracti128_si256(
                   d1,
                   0
                 )
               ),
               _mm256_bslli_epi128(
-                _mm256_zextsi128_si256(
+                zext::apply(
                   _mm256_extracti128_si256(
                     d1,
                     1
@@ -704,7 +705,7 @@ definitions:
           )
         );
   - target_extension: "avx2"
-    ctype: [] # FIXME: these implementations don't compile:  ["int64_t", "uint64_t"]
+    ctype: ["int64_t", "uint64_t"]
     additional_simd_template_base_type: ["int8_t", "uint8_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -727,7 +728,7 @@ definitions:
       auto const y = _mm256_shuffle_epi8(x, _mm256_set_epi32(0xF0B0703,0xE0A0602, 0xD090501,0xC080400, 0xF0B0703,0xE0A0602, 0xD090501,0xC080400));
       return _mm256_permutevar8x32_epi32(y, _mm256_set_epi32(7,3,6,2,5,1,4,0));
   - target_extension: "avx2"
-    ctype: [] # FIXME: these implementations don't compile:  ["int64_t", "uint64_t"]
+    ctype: ["int64_t", "uint64_t"]
     additional_simd_template_base_type: ["int16_t", "uint16_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -737,27 +738,28 @@ definitions:
       auto const d1 = _mm256_and_si256(upper_zero, data[1]);
       auto const d2 = _mm256_and_si256(upper_zero, data[2]);
       auto const d3 = _mm256_and_si256(upper_zero, data[3]);
+      using zext = functors::cast<simd<Vec::base_type, sse>, simd<Vec::base_type, avx2>, Idof>; 
       return
         _mm256_shuffle_epi8(
           _mm256_permute2x128_si256(
             _mm256_or_si256(
               _mm256_or_si256(
-                _mm256_zextsi128_si256(_mm256_extracti128_si256(d0,0)),
-                _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d0,1)),2)
+                zext::apply(_mm256_extracti128_si256(d0,0)),
+                _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d0,1)),2)
               ),
               _mm256_or_si256(
-                _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d1,0)),4),
-                _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d1,1)),6)
+                _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d1,0)),4),
+                _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d1,1)),6)
               )
             ),
             _mm256_or_si256(
               _mm256_or_si256(
-                _mm256_zextsi128_si256(_mm256_extracti128_si256(d2,0)),
-                _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d2,1)),2)
+                zext::apply(_mm256_extracti128_si256(d2,0)),
+                _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d2,1)),2)
               ),
               _mm256_or_si256(
-                _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d3,0)),4),
-                _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d3,1)),6)
+                _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d3,0)),4),
+                _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d3,1)),6)
               )
             ),
             0x20
@@ -768,7 +770,7 @@ definitions:
           )
         );
   - target_extension: "avx2"
-    ctype: [] # FIXME: these implementations don't compile: ["int64_t", "uint64_t"]
+    ctype: ["int64_t", "uint64_t"]
     additional_simd_template_base_type: ["int32_t", "uint32_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -776,16 +778,17 @@ definitions:
       auto const upper_zero = _mm256_set1_epi64x(0xffffffff);
       auto const d0 = _mm256_and_si256(upper_zero, data[0]);
       auto const d1 = _mm256_and_si256(upper_zero, data[1]);
+      using zext = functors::cast<simd<Vec::base_type, sse>, simd<Vec::base_type, avx2>, Idof>; 
       return
         _mm256_shuffle_epi32(
           _mm256_permute2x128_si256(
             _mm256_or_si256(
-              _mm256_zextsi128_si256(_mm256_extracti128_si256(d0, 0)),
-              _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d0, 1)),4)
+              zext::apply(_mm256_extracti128_si256(d0, 0)),
+              _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d0, 1)),4)
             ),
             _mm256_or_si256(
-              _mm256_zextsi128_si256(_mm256_extracti128_si256(d1, 0)),
-              _mm256_bslli_epi128(_mm256_zextsi128_si256(_mm256_extracti128_si256(d1, 1)),4)
+              zext::apply(_mm256_extracti128_si256(d1, 0)),
+              _mm256_bslli_epi128(zext::apply(_mm256_extracti128_si256(d1, 1)),4)
             ),
             0x20
           ),

--- a/primitives/convert.yaml
+++ b/primitives/convert.yaml
@@ -612,7 +612,7 @@ testing:
 definitions:
 #INTEL - AVX2
   - target_extension: "avx2"
-    ctype: ["int32_t", "uint32_t"]
+    ctype:  [] # FIXME: these implementations don't compile: ["int32_t", "uint32_t"]
     additional_simd_template_base_type: ["int8_t", "uint8_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -651,7 +651,7 @@ definitions:
 #        _mm256_cvtepi8_epi64(_mm_bsrli_si128(y, 12)),
 #      } };
   - target_extension: "avx2"
-    ctype: ["int32_t", "uint32_t"]
+    ctype: [] # FIXME: these implementations don't compile: ["int32_t", "uint32_t"]
     additional_simd_template_base_type: ["int16_t", "uint16_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -704,7 +704,7 @@ definitions:
           )
         );
   - target_extension: "avx2"
-    ctype: ["int64_t", "uint64_t"]
+    ctype: [] # FIXME: these implementations don't compile:  ["int64_t", "uint64_t"]
     additional_simd_template_base_type: ["int8_t", "uint8_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -727,7 +727,7 @@ definitions:
       auto const y = _mm256_shuffle_epi8(x, _mm256_set_epi32(0xF0B0703,0xE0A0602, 0xD090501,0xC080400, 0xF0B0703,0xE0A0602, 0xD090501,0xC080400));
       return _mm256_permutevar8x32_epi32(y, _mm256_set_epi32(7,3,6,2,5,1,4,0));
   - target_extension: "avx2"
-    ctype: ["int64_t", "uint64_t"]
+    ctype: [] # FIXME: these implementations don't compile:  ["int64_t", "uint64_t"]
     additional_simd_template_base_type: ["int16_t", "uint16_t"]
     lscpu_flags: ["avx2"]
     is_native: False
@@ -768,7 +768,7 @@ definitions:
           )
         );
   - target_extension: "avx2"
-    ctype: ["int64_t", "uint64_t"]
+    ctype: [] # FIXME: these implementations don't compile: ["int64_t", "uint64_t"]
     additional_simd_template_base_type: ["int32_t", "uint32_t"]
     lscpu_flags: ["avx2"]
     is_native: False

--- a/primitives/ls.yaml
+++ b/primitives/ls.yaml
@@ -1229,7 +1229,7 @@ definitions:
   - target_extension: "avx2"
     ctype: ["float", "double"]
     lscpu_flags: ["avx2", "avx512f", "avx512vl"]
-    implementation: "_mm256_mask_compressstoreu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), mask, _mm256_castps_si256(data));"
+    implementation: "_mm256_mask_compressstoreu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), mask, data);"
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
     lscpu_flags: ["avx2", "avx512f", "avx512vbmi2", "avx512vl"]

--- a/primitives/ls.yaml
+++ b/primitives/ls.yaml
@@ -1225,15 +1225,15 @@ definitions:
   - target_extension: "avx2"
     ctype: ["uint32_t", "int32_t", "uint64_t", "int64_t"]
     lscpu_flags: ["avx2", "avx512f", "avx512vl"]
-    implementation: "return _mm256_mask_compressstoreu_epi{{ intrin_tp[ctype][1] }}(reinterpret_cast<void*>(memory), mask, data);"
+    implementation: "_mm256_mask_compressstoreu_epi{{ intrin_tp[ctype][1] }}(reinterpret_cast<void*>(memory), mask, data);"
   - target_extension: "avx2"
     ctype: ["float", "double"]
     lscpu_flags: ["avx2", "avx512f", "avx512vl"]
-    implementation: "return _mm256_mask_compressstoreu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), mask, _mm256_castps_si256(data));"
+    implementation: "_mm256_mask_compressstoreu_{{ intrin_tp_full[ctype] }}(reinterpret_cast<void*>(memory), mask, _mm256_castps_si256(data));"
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
     lscpu_flags: ["avx2", "avx512f", "avx512vbmi2", "avx512vl"]
-    implementation: "return _mm256_mask_compressstoreu_epi{{ intrin_tp[ctype][1] }}(reinterpret_cast<void*>(memory), mask, data);"
+    implementation: "_mm256_mask_compressstoreu_epi{{ intrin_tp[ctype][1] }}(reinterpret_cast<void*>(memory), mask, data);"
 ...
 ---
 primitive_name: "expand_load"
@@ -1256,15 +1256,15 @@ definitions:
   - target_extension: "avx512"
     ctype: [ "uint32_t", "int32_t", "uint64_t", "int64_t" ]
     lscpu_flags: [ "avx512f" ]
-    implementation: "_mm512_mask_expandloadu_epi{{ intrin_tp[ctype][1] }}(src, mask, reinterpret_cast<void*>(memory));"
+    implementation: "return _mm512_mask_expandloadu_epi{{ intrin_tp[ctype][1] }}(src, mask, reinterpret_cast<void*>(memory));"
   - target_extension: "avx512"
     ctype: ["float", "double"]
     lscpu_flags: [ "avx512f" ]
-    implementation: "_mm512_mask_expandloadu_{{ intrin_tp_full[ctype] }}(src, mask, reinterpret_cast<void*>(memory));"
+    implementation: "return _mm512_mask_expandloadu_{{ intrin_tp_full[ctype] }}(src, mask, reinterpret_cast<void*>(memory));"
   - target_extension: "avx512"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
     lscpu_flags: ["avx512f", "avx512vbmi2"]
-    implementation: "_mm512_mask_expandloadu_epi{{ intrin_tp[ctype][1] }}(src, mask, reinterpret_cast<void*>(memory));"
+    implementation: "return _mm512_mask_expandloadu_epi{{ intrin_tp[ctype][1] }}(src, mask, reinterpret_cast<void*>(memory));"
   - target_extension: "avx512"
     ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t"]
     lscpu_flags: ["avx512f"]

--- a/primitives/ls.yaml
+++ b/primitives/ls.yaml
@@ -1312,7 +1312,7 @@ definitions:
   - target_extension: "avx2"
     ctype: ["float", "double"]
     lscpu_flags: ["avx2", "avx512f", "avx512vl"]
-    implementation: "return _mm256_mask_expandloadu_{{ intrin_tp_full[ctype] }}(src, mask reinterpret_cast<void const *>(memory));"
+    implementation: "return _mm256_mask_expandloadu_{{ intrin_tp_full[ctype] }}(src, mask, reinterpret_cast<void const *>(memory));"
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
     lscpu_flags: ["avx2", "avx512f", "avx512vbmi2", "avx512vl"]

--- a/primitives/mask.yaml
+++ b/primitives/mask.yaml
@@ -306,7 +306,7 @@ returns:
 definitions:
   #INTEL - AVX512
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
     lscpu_flags: ['avx512f']
     implementation: "return mask;"
   #INTEL - AVX2
@@ -405,7 +405,7 @@ returns:
 definitions:
   #INTEL - AVX512
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
     lscpu_flags: ['avx512f', 'avx512dq', 'avx512bw']
     implementation: "return _kand_mask{{ intrin_tp[ctype][1] }}(first, second);"
   - target_extension: "avx512"
@@ -417,7 +417,7 @@ definitions:
     lscpu_flags: ['avx512f', 'avx512dq']
     implementation: "return _kand_mask8(first, second);"
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "double"] #no float
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "double"] #no float
     lscpu_flags: ['avx512f']
     implementation: "return first & second;"
   #INTEL AVX2
@@ -513,7 +513,7 @@ returns:
 definitions:
   #INTEL - AVX512
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
     lscpu_flags: ['avx512f', 'avx512dq', 'avx512bw']
     implementation: "return _kor_mask{{ intrin_tp[ctype][1] }}(first, second);"
   - target_extension: "avx512"
@@ -525,7 +525,7 @@ definitions:
     lscpu_flags: ['avx512f', 'avx512dq']
     implementation: "return _kor_mask8(first, second);"
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "double"] #no float
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "double"] #no float
     lscpu_flags: ['avx512f']
     implementation: "return first | second;"
   #INTEL AVX2
@@ -621,7 +621,7 @@ returns:
 definitions:
   #INTEL - AVX512
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t"]
     lscpu_flags: ['avx512f', 'avx512dq', 'avx512bw']
     implementation: "return _kxor_mask{{ intrin_tp[ctype][1] }}(first, second);"
   - target_extension: "avx512"
@@ -633,7 +633,7 @@ definitions:
     lscpu_flags: ['avx512f', 'avx512dq']
     implementation: "return _kxor_mask8(first, second);"
   - target_extension: "avx512"
-    ctype: ["int8_t", "uint8_t", "int16_t", "uin16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "double"] #no float
+    ctype: ["int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "double"] #no float
     lscpu_flags: ['avx512f']
     implementation: "return first ^ second;"
   #INTEL AVX2

--- a/primitives/misc.yaml
+++ b/primitives/misc.yaml
@@ -128,7 +128,7 @@ definitions:
     ctype: ["uint32_t", "uint64_t","int32_t", "int64_t"]
     lscpu_flags: ["avx512f", "avx512cd"]
     implementation: |
-      auto const conflict_reg = _mm512_maskz_conflict_epi{{ intrin_tp[ctype][1] }}(data);
+      auto const conflict_reg = _mm512_maskz_conflict_epi{{ intrin_tp[ctype][1] }}(mask, data);
       auto const mask_reg = _mm512_set1_epi{{ intrin_tp[ctype][1] }}(mask);
       auto const cleaned_conflict_reg = _mm512_and_si512(conflict_reg, mask_reg);
       return _mm512_mask_cmpeq_epi{{ intrin_tp[ctype][1] }}_mask(mask, cleaned_conflict_reg, _mm512_setzero_si512());
@@ -292,14 +292,14 @@ definitions:
     is_native: False
     implementation: |
       auto const right_added_part = _mm512_add_epi{{ intrin_tp[ctype][1] }}(right, adder);
-      return _mm512_mask_blend_epi{{ intrin_tp[ctype][1] }}(control, right_added, left);
+      return _mm512_mask_blend_epi{{ intrin_tp[ctype][1] }}(control, right_added_part, left);
   - target_extension: "avx512"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t"]
     lscpu_flags: ["avx512f", "avx512bw"]
     is_native: False
     implementation: |
       auto const right_added_part = _mm512_add_epi{{ intrin_tp[ctype][1] }}(right, adder);
-      return _mm512_mask_blend_epi{{ intrin_tp[ctype][1] }}(control, right_added, left);
+      return _mm512_mask_blend_epi{{ intrin_tp[ctype][1] }}(control, right_added_part, left);
   #INTEL - AVX2
   - target_extension: "avx2"
     ctype: ["uint8_t", "int8_t", "uint16_t", "int16_t", "uint32_t", "int32_t", "uint64_t", "int64_t"]


### PR DESCRIPTION
Since we agreed on using this branch as a base of operations, 
it is very unfortunate that it currently does not compile.

This PR brings us back to working compilation by fixing a few minor issues.
Unfortunately, one specific implementation (convert_down on avx2) had to be temporarily disabled because the compilations issues were more severe, out of scope for a simple fix like this. 